### PR TITLE
sign_rpm_ext.bbclass: remove prefuncs for do_package_write_rpm and

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -17,9 +17,6 @@ python check_rpm_public_key () {
 }
 
 check_rpm_public_key[lockfiles] = "${TMPDIR}/gpg_key.lock"
-do_package_write_rpm[prefuncs] += "check_rpm_public_key"
-do_rootfs[prefuncs] += "check_rpm_public_key"
-
 check_rpm_public_key[prefuncs] += "check_deploy_keys"
 do_package_write_rpm[depends] += "${GPG_DEP}"
 do_rootfs[depends] += "${GPG_DEP}"


### PR DESCRIPTION
do_rootfs

in commit 393b80fa, prefuncs of do_package_write_rpm/do_rootfs
have been replace by (task)_prepend in this bbclass, so remove it.

Signed-off-by: Changqing Li <changqing.li@windriver.com>